### PR TITLE
Show homebrew/versions is required in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ To use these formulae,
 
 ```bash
 $ brew tap cosmo0920/mingw_w64
+$ brew tap homebrew/versions
 ```
 
 and then,


### PR DESCRIPTION
Users need to run `brew tap homebrew/versions` before installing
formulas like `gcc-mingw32` because there are dependencies on packages
like gcc48. Add that to README.md.
